### PR TITLE
ensure consistency with config.yaml and config.schema.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,7 @@ setup:
 
 aws_access_key_id: null
 aws_secret_access_key: null
-region: ""
+region: "us-east-1"
 interval: 20
 st2_user_data: "/opt/stackstorm/packs/aws/actions/scripts/bootstrap_user.sh"
 


### PR DESCRIPTION
The default `region` parameter is specified `us-east-1` in `config.schema.yaml`.
But in the `config.yaml`, `region` parameter is blank.

This patch keeps a consistency of default value with each configuration mechanism.