### PR TITLE
Corrected 'filters' parameter type of 'vpc_get_all_subnets' action

### DIFF
--- a/actions/vpc_get_all_subnets.yaml
+++ b/actions/vpc_get_all_subnets.yaml
@@ -15,7 +15,7 @@ parameters:
     default: false
     type: boolean
   filters:
-    type: string
+    type: object
   module_path:
     default: boto.vpc
     immutable: true

--- a/pack.yaml
+++ b/pack.yaml
@@ -18,6 +18,6 @@ keywords:
   - RDS
   - SQS
 
-version : 0.7.6
+version : 0.7.7
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/tests/test_action_vpc_get_all_subnets.py
+++ b/tests/test_action_vpc_get_all_subnets.py
@@ -1,0 +1,64 @@
+import mock
+
+from boto.connection import AWSQueryConnection
+
+from run import ActionManager
+from aws_base_action_test_case import AWSBaseActionTestCase
+
+DUMMY_RAW_RESPONSE = """
+<DescribeSubnetsResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
+    <requestId>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</requestId>
+    <subnetSet>
+        <item>
+            <subnetId>subnet-foo</subnetId>
+            <state>available</state>
+            <vpcId>vpc-hoge</vpcId>
+            <cidrBlock>10.0.0.0/24</cidrBlock>
+        </item>
+        <item>
+            <subnetId>subnet-bar</subnetId>
+            <state>available</state>
+            <vpcId>vpc-fuga</vpcId>
+            <cidrBlock>172.30.0.0/24</cidrBlock>
+        </item>
+        <item>
+            <subnetId>subnet-baz</subnetId>
+            <state>available</state>
+            <vpcId>vpc-fuga</vpcId>
+            <cidrBlock>172.30.2.0/24</cidrBlock>
+        </item>
+    </subnetSet>
+</DescribeSubnetsResponse>
+"""
+
+MOCK_RESPONSE = mock.Mock()
+MOCK_RESPONSE.status = 200
+MOCK_RESPONSE.read = mock.Mock(return_value=DUMMY_RAW_RESPONSE)
+
+
+@mock.patch.object(AWSQueryConnection, 'make_request', mock.Mock(return_value=MOCK_RESPONSE))
+class VPCGetAllSubnetsTestCase(AWSBaseActionTestCase):
+    __test__ = True
+    action_cls = ActionManager
+
+    def setUp(self):
+        super(VPCGetAllSubnetsTestCase, self).setUp()
+        self._params = {
+            'module_path': 'boto.vpc',
+            'cls': 'VPCConnection',
+            'action': 'get_all_subnets',
+        }
+
+    def test_get_subnets(self):
+        action = self.get_action_instance(self.full_config)
+        result = action.run(**self._params)
+
+        self.assertTrue(isinstance(result, list))
+        self.assertEqual(len(result), 3)
+
+    def test_get_subnets_with_filter(self):
+        self._params['filters'] = {'hoge': 'fuga'}
+        action = self.get_action_instance(self.full_config)
+        result = action.run(**self._params)
+
+        self.assertTrue(isinstance(result, list))


### PR DESCRIPTION
This is the correction of #11.

The reason of this program is the incorrect parameter type of 'filters'.

The [boto.vpc.VPCConnection.get_all_subnets](http://boto.cloudhackers.com/en/latest/ref/vpc.html#boto.vpc.VPCConnection.get_all_subnets) requires `filters` parameter requires 'list' of 'dict' type, but the 'aws.vpc_get_all_subnets' action requires 'string' type.

So I corrected the parameter type of it from 'string' to 'object'.

By this patch, user can use this action with `filters` parameter normally like this.
```
(virtualenv)vagrant@ubuntu2:~$ st2 action get aws.vpc_get_all_subnets
+-------------+----------------------------------------+
| Property    | Value                                  |
+-------------+----------------------------------------+
| id          | 5880676c88fa3f03a3fcc791               |
| uid         | action:aws:vpc_get_all_subnets         |
| ref         | aws.vpc_get_all_subnets                |
| pack        | aws                                    |
| name        | vpc_get_all_subnets                    |
| description |                                        |
| enabled     | True                                   |
| entry_point | run.py                                 |
| runner_type | run-python                             |
| parameters  | {                                      |
|             |     "dry_run": {                       |
|             |         "default": false,              |
|             |         "type": "boolean"              |
|             |     },                                 |
|             |     "filters": {                       |
|             |         "type": "object"               |
|             |     },                                 |
|             |     "action": {                        |
|             |         "default": "get_all_subnets",  |
|             |         "type": "string",              |
|             |         "immutable": true              |
|             |     },                                 |
|             |     "module_path": {                   |
|             |         "default": "boto.vpc",         |
|             |         "type": "string",              |
|             |         "immutable": true              |
|             |     },                                 |
|             |     "subnet_ids": {                    |
|             |         "type": "string"               |
|             |     },                                 |
|             |     "cls": {                           |
|             |         "default": "VPCConnection",    |
|             |         "type": "string",              |
|             |         "immutable": true              |
|             |     }                                  |
|             | }                                      |
| notify      |                                        |
| tags        |                                        |
+-------------+----------------------------------------+
(virtualenv)vagrant@ubuntu2:~$ st2 run aws.vpc_get_all_subnets filters='vpc_id=vpc-8e5aaceb'
..
id: 5880978388fa3f283f10d2ab
status: succeeded
parameters: 
  filters:
    vpc_id: vpc-8e5aaceb
result: 
  exit_code: 0
  result:
  - availability_zone: ap-northeast-1a
    available_ip_address_count: 251
    cidr_block: 172.30.0.0/24
    defaultForAz: 'false'
    id: subnet-aa08fedd
    item: "
        "
    mapPublicIpOnLaunch: 'true'
    region: ap-northeast-1
    state: available
    tags: {}
    vpc_id: vpc-8e5aaceb
  - availability_zone: ap-northeast-1c
    available_ip_address_count: 251
    cidr_block: 172.30.2.0/24
    defaultForAz: 'false'
    id: subnet-c8b8b28e
    item: "
        "
    mapPublicIpOnLaunch: 'true'
    region: ap-northeast-1
    state: available
    tags: {}
    vpc_id: vpc-8e5aaceb
  stderr: ''
  stdout: ''
(virtualenv)vagrant@ubuntu2:~$ 
```