### PR TITLE
corrected the test for CloudFormation

### DIFF
--- a/tests/test_action_cloudformation.py
+++ b/tests/test_action_cloudformation.py
@@ -1,18 +1,27 @@
 import mock
 
+from run import ActionManager
 from aws_base_action_test_case import AWSBaseActionTestCase
 
 from boto.cloudformation.connection import CloudFormationConnection
 
 
 class CloudFormationTestCase(AWSBaseActionTestCase):
-    action_cls = CloudFormationConnection
+    __test__ = True
+    action_cls = ActionManager
+
+    def setUp(self):
+        super(CloudFormationTestCase, self).setUp()
+        self._params = {
+            'module_path': 'boto.cloudformation.connection',
+            'cls': 'CloudFormationConnection',
+        }
 
     @mock.patch.object(CloudFormationConnection, 'get_path', mock.Mock(return_value='hoge'))
-    def test_connect(self):
+    def test_connection(self):
         self._params['action'] = 'get_path'
 
         action = self.get_action_instance(self.full_config)
         result = action.run(**self._params)
 
-        self.assertEqual(result, 'hoge')
+        self.assertEqual(result, ['hoge'])


### PR DESCRIPTION
A minimal test for the CloudFormation which I wrote in #8 was incorrect and wasn't set to test.
Sorry, It's my fault.

This patch is the correction of it.

__Note: About the bumping version__
This is the correction only of a test. I guess that there is no motivation for user to upgrade this pack by this.
So I dare not to bump version in this case.

Thank you.