### PR TITLE
Corrected entries on the example config.

### DIFF
--- a/aws.example.yaml
+++ b/aws.example.yaml
@@ -1,6 +1,6 @@
 ---
-aws_access_key_id: AKIAJWNYSQSDZRUXGGVA
-aws_secret_access_key: fPaNa2OMPsGG17RCB54pYra5svW9UcZKAdxbX620
+aws_access_key_id: access_key
+aws_secret_access_key: secret_key
 region: us-east-1
 interval: 20
 st2_user_data: /opt/stackstorm/packs/aws/actions/scripts/bootstrap_user.sh


### PR DESCRIPTION
I added an invalid `access_key` and `secret_key` pair to the example of aws pack config in the previous commit(adff633).
But this description misleads that many people this had security problem.

This patch corrects it with reference to [this commit](https://github.com/StackStorm-Exchange/stackstorm-vsphere/commit/44d0a744d66a67417ad3872000aef9507078d189).
