### PR TITLE
Fix boto3 actions - they never worked since we never passed in credentials

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.9.2
+
+* Fix all the boto3 actions (autoscaling, etc.) so they work. Previously they didn't work because
+  credentials weren't correctly passed in. #26
+
 ## v0.9.1
 
 * Corrected incomplete error handling and validation of configuration (#22).

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -76,7 +76,7 @@ class BaseAction(Action):
     def get_boto3_session(self, resource):
         region = self.credentials['region']
         del self.credentials['region']
-        return boto3.client(resource, region_name=region)
+        return boto3.client(resource, region_name=region, **self.credentials)
 
     def split_tags(self, tags):
         tag_dict = {}
@@ -126,7 +126,7 @@ class BaseAction(Action):
             zone = kwargs['zone']
             del kwargs['zone']
             obj = self.get_r53zone(zone)
-        elif "boto3" in module_path:
+        elif 'boto3' in module_path:
             for k, v in kwargs.items():
                 if not v:
                     del kwargs[k]

--- a/pack.yaml
+++ b/pack.yaml
@@ -19,6 +19,6 @@ keywords:
   - SQS
   - lambda
 
-version : 0.9.1
+version : 0.9.2
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
The title says it all - it appears those actions never worked since we never passed in credentials so authentication never succeeded. 

```bash
Traceback (most recent call last):
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py", line 259, in <module>
    obj.run()
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py", line 155, in run
    output = action.run(**self._parameters)
  File "/opt/stackstorm/packs/aws/actions/run.py", line 20, in run
    return self.do_method(module_path, cls, action, **kwargs)
  File "/opt/stackstorm/packs/aws/actions/lib/action.py", line 142, in do_method
    resultset = getattr(obj, action)(**kwargs)
  File "/opt/stackstorm/virtualenvs/aws/lib/python2.7/site-packages/botocore/client.py", line 251, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/opt/stackstorm/virtualenvs/aws/lib/python2.7/site-packages/botocore/client.py", line 526, in _make_api_call
    operation_model, request_dict)
  File "/opt/stackstorm/virtualenvs/aws/lib/python2.7/site-packages/botocore/endpoint.py", line 141, in make_request
    return self._send_request(request_dict, operation_model)
  File "/opt/stackstorm/virtualenvs/aws/lib/python2.7/site-packages/botocore/endpoint.py", line 166, in _send_request
    request = self.create_request(request_dict, operation_model)
  File "/opt/stackstorm/virtualenvs/aws/lib/python2.7/site-packages/botocore/endpoint.py", line 150, in create_request
    operation_name=operation_model.name)
  File "/opt/stackstorm/virtualenvs/aws/lib/python2.7/site-packages/botocore/hooks.py", line 227, in emit
    return self._emit(event_name, kwargs)
  File "/opt/stackstorm/virtualenvs/aws/lib/python2.7/site-packages/botocore/hooks.py", line 210, in _emit
    response = handler(**kwargs)
  File "/opt/stackstorm/virtualenvs/aws/lib/python2.7/site-packages/botocore/signers.py", line 90, in handler
    return self.sign(operation_name, request)
  File "/opt/stackstorm/virtualenvs/aws/lib/python2.7/site-packages/botocore/signers.py", line 147, in sign
    auth.add_auth(request)
  File "/opt/stackstorm/virtualenvs/aws/lib/python2.7/site-packages/botocore/auth.py", line 316, in add_auth
    raise NoCredentialsError
botocore.exceptions.NoCredentialsError: Unable to locate credentials
```