### PR TITLE
allow region to be set independently of keys

### DIFF
--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -43,6 +43,9 @@ class BaseAction(Action):
             # Assume old-style config
             self.credentials = config['setup']
 
+        if region:
+            self.credentials['region'] = region
+
         self.resultsets = ResultSets()
 
     def ec2_connect(self):


### PR DESCRIPTION
Could do with someone double checking, but if you set the following in your config

```
aws_access_key_id: ""
aws_secret_access_key: ""
region: "eu-west-1"
```

with the current setup region is never set. This is legitimate configuration where iam roles are used for st2

The change allows this to be set independently 

