### PR TITLE
Fix 'tags' parameter to be an object

### DIFF
--- a/actions/cf_create_stack.yaml
+++ b/actions/cf_create_stack.yaml
@@ -33,7 +33,7 @@ parameters:
   stack_policy_url:
     type: string
   tags:
-    type: string
+    type: object
   template_body:
     type: string
   template_url:


### PR DESCRIPTION
The `CloudFormation.create_stack` method expects the `tags` argument to be a `dict`, and should be represented by `object` in this schema. Verified this against the aws pack v0.11.0.