### PR TITLE
Adding latest boto3 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 six
 boto>=2.41.0,<2.42
 # Note: boto3 is used by the SQS sensor
-boto3>=1.3.1,<1.4
+boto3==1.4.5
 flask>=0.10.1


### PR DESCRIPTION
Update python virtualenv to install boto3 version 1.4.5. Since `aws.boto3action` focus on  providing access to capabilities in boto3, having the latest version of boto3 makes sense to me.