### PR TITLE
Add 0.11.0 and 1.0.0 to CHANGES.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.0
+
+- Updated actions from boto to boto3 using st2packgen.py. 2244 actions were added (#35).
+
+## 0.11.0
+
+- Add capability for st2packgen.py to generate actions for all available services. Map stype "float"
+  to "number".
+
 ## 0.10.0
 
 - Updated action `runner_type` from `run-python` to `python-script`

--- a/pack.yaml
+++ b/pack.yaml
@@ -19,6 +19,6 @@ keywords:
   - SQS
   - lambda
 
-version : 0.11.0
+version : 1.0.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Bump `pack.yaml` to 1.0.0 to reflect the updated actions pushed a few weeks ago.

**0.11.0**
 - Add capability for `st2packgen.py` to generate actions for all available services. Map new `"float"` `stype` to `"number"`.

**1.0.0**
 - Update actions using `st2packgen.py`. 2244 actions were added, reflecting the changes to the API since the last update (#35).

