### PR TITLE
boto3 branch version update

### DIFF
--- a/pack.yaml
+++ b/pack.yaml
@@ -19,6 +19,6 @@ keywords:
   - SQS
   - lambda
 
-version : 0.12.0
+version : 0.1.0-boto3
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
@lakshmi-kannan and I decided that pack version on boto3 branch should be of the format `semver-branch`, rather than interleaving master and boto3 versions.