### PR TITLE
allow region to be set independently, and keys to be empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ You can generate the access key and secret access key by following these directi
 http://docs.aws.amazon.com/IAM/latest/UserGuide/ManagingCredentials.html#Using_CreateAccessKey
 
 If you would like to use the IAM role assigned to the instance stackstorm is running set the
-key and secret to null and set the region.
+key and secret to None and set the region.
 
 ```yaml
 ---
 region: "us-east-1"
-aws_access_key_id: null
-aws_secret_access_key: null
+aws_access_key_id: None
+aws_secret_access_key: None
 st2_user_data: ""
  ```
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ aws_secret_access_key: None
 st2_user_data: ""
  ```
 
+In previous versions there was a 'setup' object within the config, which has been deprecated. This will
+break the configuration where iam roles are being used
+
 * ``service_notifications_sensor.host`` - Listen host for the HTTP interface.
 * ``service_notifications_sensor.port`` - Listen port for the HTTP interface.
 * ``service_notifications_sensor.path`` - Path where the events need to be sent.

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -37,13 +37,20 @@ class BaseAction(Action):
         secret_access_key = config.get('aws_secret_access_key', None)
         region = config.get('region', None)
 
+        if access_key_id == "None":
+            access_key_id = None
+        if secret_access_key == "None":
+            secret_access_key = None
+
         if access_key_id and secret_access_key:
             self.credentials['aws_access_key_id'] = access_key_id
             self.credentials['aws_secret_access_key'] = secret_access_key
-            self.credentials['region'] = region
         elif 'setup' in config:
             # Assume old-style config
             self.credentials = config['setup']
+
+        if region:
+            self.credentials['region'] = region
 
         self.resultsets = ResultSets()
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -18,7 +18,8 @@ keywords:
   - RDS
   - SQS
   - lambda
+  - kinesis
 
-version : 1.0.0
+version : 1.0.1
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
This PR addresses 2 issues:

- region should still be set regardless of whether access keys are set
- when setting access keys to None, stackstorm converts to a string and boto3 tries (and fails to use them)


the readme for this pack specifies:

> If you would like to use the IAM role assigned to the instance stackstorm is running set the key and secret to null and set the region.
> 
> ---
> region: "us-east-1"
> aws_access_key_id: null
> aws_secret_access_key: null
> st2_user_data: ""

however 'null' isn't allowed (throws an error that it doesnt validate against the schema), and nor does None as this gets converted to a string. These are required parameters though

Where someone is using iam roles these aren't needed, setting to None, or "", will cause boto3 to throw an error:

>botocore.exceptions.ClientError: An error occurred (InvalidClientTokenId) when calling the DescribeDBParameterGroups operation: The security token included in the request is invalid.

Setting these explicitly to None fixes this issue, however a new error is thrown:

> botocore.exceptions.NoRegionError: You must specify a region.

This should therefore be set separately:

`        if region:
            self.credentials['region'] = region`