### PR TITLE
Fix actions which operate with tags on AWS resources

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.2
+
+- Fix actions which operate with tags on AWS resources.
+
 ## 1.0.0
 
 - Updated actions from boto to boto3 using st2packgen.py. 2244 actions were added (#35).

--- a/actions/run.py
+++ b/actions/run.py
@@ -1,22 +1,30 @@
+'''
+ST2 AWS pack action runner script
+'''
+
 from lib import action
 
 
 class ActionManager(action.BaseAction):
+    '''
+    Main action class
+    '''
 
     def run(self, **kwargs):
-        action = kwargs['action']
-        del kwargs['action']
-        module_path = kwargs['module_path']
-        del kwargs['module_path']
-        if action == 'run_instances':
+        '''
+        Action runner method
+        '''
+        aws_action = kwargs.pop('action')
+        module_path = kwargs.pop('module_path')
+        if aws_action == 'run_instances':
             kwargs['user_data'] = self.st2_user_data()
-        if action == 'create_tags':
-            kwargs['tags'] = self.split_tags(kwargs['tags'])
-        if action in ('add_a', 'update_a'):
+        if aws_action == 'create_tags':
+            # Skip "Tags" parameter and pass "tags" as is unless it is a string.
+            if 'Tags' not in kwargs and isinstance(kwargs.get('tags'), str):
+                kwargs['tags'] = self.split_tags(kwargs['tags'])
+        if aws_action in ('add_a', 'update_a'):
             kwargs['value'] = kwargs['value'].split(',')
         if 'cls' in kwargs.keys():
-            cls = kwargs['cls']
-            del kwargs['cls']
-            return self.do_method(module_path, cls, action, **kwargs)
-        else:
-            return self.do_function(module_path, action, **kwargs)
+            cls = kwargs.pop('cls')
+            return self.do_method(module_path, cls, aws_action, **kwargs)
+        return self.do_function(module_path, aws_action, **kwargs)

--- a/pack.yaml
+++ b/pack.yaml
@@ -20,6 +20,6 @@ keywords:
   - lambda
   - kinesis
 
-version : 1.0.1
+version : 1.0.2
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
I have found few issues with actions which intend to set tags in AWS (they have immutable parameter `action: create_tags`).
* Action has `Tags` parameter of `array` type. It seems that such parameter should be passed directly to `boto3` fuction. For example: `aws.ec2_create_tags`.
* Action has `tags` (lowercase) parameter of type `array`. Similar to `Tags` above, it is expected that they should satisfy Boto call. For example `aws.discovery_create_tags`.
* Action has `tags` parameter of type `string`. Format is: `key1=value1,key2=value2,...`. For example: `aws.vpc_create_tags`.

This PR fixes `run.py` action runner script by transforming `tags` kwarg to a list of dicts if it is a string, otherwise pass `Tags` or `tags` untouched straight to Boto3 action.

Affected actions are:
* aws.ec2_create_tags
* aws.efs_create_tags
* aws.discovery_create_tags
* aws.redshift_create_tags
* aws.vpc_create_tags
* aws.workspaces_create_tags

@LindsayHill Could you please review my PR? Thank you.
