### PR TITLE
Change create_vm to use CamelCase

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.3
+
+- Fixed issue with create_vm and destroy_vm workflows using snake_case for CamelCase params
+
 ## 1.0.2
 
 - Fix actions which operate with tags on AWS resources.

--- a/actions/create_vm.meta.yaml
+++ b/actions/create_vm.meta.yaml
@@ -5,22 +5,18 @@
   enabled: true
   entry_point: "workflows/create_vm.yaml"
   parameters:
-    image_id:
+    ImageId:
       type: "string"
       description: "AWS image id to create instance from"
       required: true
-    instance_type:
+    InstanceType:
       type: "string"
       description: "Flavor to use for instance creation"
       default: "t2.medium"
-    key_name:
+    KeyName:
       type: "string"
       description: "SSH key to use during intial instance creation"
       required: true
-    base_user:
-      type: "string"
-      description: "Username for initial ssh test"
-      default: "ubuntu"
     keyfile:
       type: "string"
       description: "Path to local private key that corresponds to {{key_name}}"
@@ -33,7 +29,7 @@
       type: "string"
       description: "Short hostname"
       required: true
-    subnet_id:
+    SubnetId:
       type: "string"
       description: "AWS Subnet ID"
       required: true

--- a/actions/workflows/create_vm.yaml
+++ b/actions/workflows/create_vm.yaml
@@ -4,10 +4,10 @@
       name: "run_instance"
       ref: "aws.ec2_run_instances"
       params:
-        image_id: "{{image_id}}"
-        instance_type: "{{instance_type}}"
-        subnet_id: "{{subnet_id}}"
-        key_name: "{{key_name}}"
+        ImageId: "{{Image_id}}"
+        InstanceType: "{{InstanceType}}"
+        SubnetId: "{{SubnetId}}"
+        KeyName: "{{KeyName}}"
       on-success: "wait_for_instance"
     -
       name: "wait_for_instance"
@@ -30,8 +30,8 @@
       name: "add_name_tag"
       ref: "aws.ec2_create_tags"
       params:
-        resource_ids: "{{run_instance.result[0][0].id}}"
-        tags: "Name={{hostname}}"
+        Resources: "{{run_instance.result[0][0].id}}"
+        Tags: "Name={{hostname}}"
       on-success: "add_cname"
     -
       name: "add_cname"

--- a/actions/workflows/destroy_vm.yaml
+++ b/actions/workflows/destroy_vm.yaml
@@ -22,7 +22,7 @@
       name: "destroy_vm"
       ref: "aws.ec2_terminate_instances"
       params:
-        instance_ids: "{{id.localhost.stdout}}"
+        InstanceIds: "{{id.localhost.stdout}}"
       on-success: "delete_cname"
     -
       name: "delete_cname"

--- a/pack.yaml
+++ b/pack.yaml
@@ -20,6 +20,6 @@ keywords:
   - lambda
   - kinesis
 
-version : 1.0.2
+version : 1.0.3
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Somewhere along the line we changed st2packgen.py, and it switched to CamelCase for parameters, not snake_case.

This broke `create_vm` and `destroy_vm` workflows.

Fixes #61 