### PR TITLE
Allow user to pass "user_data" parameter to the ec2_run_instances action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.1.0
+
+- Fix ``ec2_run_instances`` action so ``user_data`` parameter passed to this action takes
+  precedence over user data which is specified via ``st2_user_data`` config option.
+
+  This way user can override / provide custom user data on per action invocation basis.
+
+- Add additional log statements under debug log level which logs which boto method / function
+  is called and with which arguments. This helps with debugging / troubleshooting various
+  pack related issues.
+
 ## 1.0.3
 
 - Fixed issue with create_vm and destroy_vm workflows using snake_case for CamelCase params

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,9 +7,9 @@
 
   This way user can override / provide custom user data on per action invocation basis.
 
-- Add additional log statements under debug log level which logs which boto method / function
-  is called and with which arguments. This helps with debugging / troubleshooting various
-  pack related issues.
+- Add additional log statements under debug log level which log which boto method / function
+  is called and with which arguments when ``debug`` config option is set to ``True``. This helps
+  with debugging / troubleshooting various pack related issues.
 
 ## 1.0.3
 

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -165,6 +165,7 @@ class BaseAction(Action):
 
         if self.debug:
             function_fqdn = '%s.%s' % (module_path, action)
-            self.logger.debug('Calling function "%s" with kwargs: %s' % (function_fqdn, str(kwargs)))
+            self.logger.debug('Calling function "%s" with kwargs: %s' % (function_fqdn,
+                                                                         str(kwargs)))
 
         return getattr(module, action)(**kwargs)

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -23,6 +23,7 @@ class BaseAction(Action):
             'aws_secret_access_key': None
         }
         self.user_data_file = config.get('st2_user_data', None)
+        self.debug = config.get('debug', False)
 
         self.userdata = None
 
@@ -151,8 +152,9 @@ class BaseAction(Action):
             raise ValueError('Invalid or missing credentials (aws_access_key_id,'
                              'aws_secret_access_key) or region')
 
-        method_fqdn = '%s.%s.%s' % (module_path, cls, action)
-        self.logger.debug('Calling method "%s" with kwargs: %s' % (method_fqdn, str(kwargs)))
+        if self.debug:
+            method_fqdn = '%s.%s.%s' % (module_path, cls, action)
+            self.logger.debug('Calling method "%s" with kwargs: %s' % (method_fqdn, str(kwargs)))
 
         resultset = getattr(obj, action)(**kwargs)
         formatted = self.resultsets.formatter(resultset)
@@ -161,7 +163,8 @@ class BaseAction(Action):
     def do_function(self, module_path, action, **kwargs):
         module = __import__(module_path)
 
-        function_fqdn = '%s.%s' % (module_path, action)
-        self.logger.debug('Calling function "%s" with kwargs: %s' % (function_fqdn, str(kwargs)))
+        if self.debug:
+            function_fqdn = '%s.%s' % (module_path, action)
+            self.logger.debug('Calling function "%s" with kwargs: %s' % (function_fqdn, str(kwargs)))
 
         return getattr(module, action)(**kwargs)

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -22,11 +22,14 @@ class BaseAction(Action):
             'aws_access_key_id': None,
             'aws_secret_access_key': None
         }
+        self.user_data_file config.get('st2_user_data', None)
+
         self.userdata = None
 
-        if config.get('st2_user_data', None):
+        # Read in default user data
+        if self.user_data_file:
             try:
-                with open(config['st2_user_data'], 'r') as fp:
+                with open(self.user_data_file, 'r') as fp:
                     self.userdata = fp.read()
             except IOError as e:
                 self.logger.error(e)

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -148,10 +148,17 @@ class BaseAction(Action):
             raise ValueError('Invalid or missing credentials (aws_access_key_id,'
                              'aws_secret_access_key) or region')
 
+        method_fqdn = '%s.%s.%s' % (module_path, cls, action)
+        self.logger.debug('Calling method "%s" with kwargs: %s' % (method_fqdn, str(kwargs)))
+
         resultset = getattr(obj, action)(**kwargs)
         formatted = self.resultsets.formatter(resultset)
         return formatted if isinstance(formatted, list) else [formatted]
 
     def do_function(self, module_path, action, **kwargs):
         module = __import__(module_path)
+
+        function_fqdn = '%s.%s' % (module_path,  action)
+        self.logger.debug('Calling function "%s" with kwargs: %s' % (function_fqdn, str(kwargs)))
+
         return getattr(module, action)(**kwargs)

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -158,7 +158,7 @@ class BaseAction(Action):
     def do_function(self, module_path, action, **kwargs):
         module = __import__(module_path)
 
-        function_fqdn = '%s.%s' % (module_path,  action)
+        function_fqdn = '%s.%s' % (module_path, action)
         self.logger.debug('Calling function "%s" with kwargs: %s' % (function_fqdn, str(kwargs)))
 
         return getattr(module, action)(**kwargs)

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -22,7 +22,7 @@ class BaseAction(Action):
             'aws_access_key_id': None,
             'aws_secret_access_key': None
         }
-        self.user_data_file config.get('st2_user_data', None)
+        self.user_data_file = config.get('st2_user_data', None)
 
         self.userdata = None
 

--- a/actions/run.py
+++ b/actions/run.py
@@ -16,7 +16,7 @@ class ActionManager(action.BaseAction):
         '''
         aws_action = kwargs.pop('action')
         module_path = kwargs.pop('module_path')
-        if aws_action == 'run_instances':
+        if aws_action == 'run_instances' and 'user_data' not in kwargs:
             kwargs['user_data'] = self.st2_user_data()
         if aws_action == 'create_tags':
             # Skip "Tags" parameter and pass "tags" as is unless it is a string.

--- a/actions/run.py
+++ b/actions/run.py
@@ -17,6 +17,7 @@ class ActionManager(action.BaseAction):
         aws_action = kwargs.pop('action')
         module_path = kwargs.pop('module_path')
         if aws_action == 'run_instances' and 'user_data' not in kwargs:
+            self.logger.info('Passing in default user_data from st2_user_data config option')
             kwargs['user_data'] = self.st2_user_data()
         if aws_action == 'create_tags':
             # Skip "Tags" parameter and pass "tags" as is unless it is a string.

--- a/actions/run.py
+++ b/actions/run.py
@@ -16,7 +16,7 @@ class ActionManager(action.BaseAction):
         '''
         aws_action = kwargs.pop('action')
         module_path = kwargs.pop('module_path')
-        if aws_action == 'run_instances' and 'user_data' not in kwargs:
+        if aws_action == 'run_instances' and not kwargs.get('user_data', None):
             self.logger.info('Passing in default user_data from st2_user_data config option')
             kwargs['user_data'] = self.st2_user_data()
         if aws_action == 'create_tags':

--- a/actions/run.py
+++ b/actions/run.py
@@ -17,8 +17,13 @@ class ActionManager(action.BaseAction):
         aws_action = kwargs.pop('action')
         module_path = kwargs.pop('module_path')
         if aws_action == 'run_instances' and not kwargs.get('user_data', None):
-            self.logger.info('Passing in default user_data from st2_user_data config option')
-            kwargs['user_data'] = self.st2_user_data()
+            # Include default user_data from config (if set)
+            user_data = self.st2_user_data()
+
+            if user_data:
+                self.logger.info('Passing in default user_data specified as st2_user_data config '
+                                 'option (%s file)' % (self.user_data_file))
+                kwargs['user_data'] = self.st2_user_data()
         if aws_action == 'create_tags':
             # Skip "Tags" parameter and pass "tags" as is unless it is a string.
             if 'Tags' not in kwargs and isinstance(kwargs.get('tags'), str):

--- a/aws.yaml.example
+++ b/aws.yaml.example
@@ -3,6 +3,7 @@ aws_access_key_id: access_key
 aws_secret_access_key: secret_key
 region: us-east-1
 st2_user_data: /opt/stackstorm/packs/aws/actions/scripts/bootstrap_user.sh
+debug: true
 
 service_notifications_sensor:
   host: localhost

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -17,6 +17,10 @@
   st2_user_data:
     description: "The file for all invocations of the 'aws.ec2_run_instances' action"
     type: "string"
+  debug:
+    type: "boolean"
+    description: "Set to True to log every boto method / function invocation"
+    default: false
   service_notifications_sensor:
     type: object
     properties:

--- a/pack.yaml
+++ b/pack.yaml
@@ -20,6 +20,6 @@ keywords:
   - lambda
   - kinesis
 
-version : 1.0.3
+version : 1.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Right now, if user passes `user_data` parameter to ` ec2_run_instances` it's silently ignored if pack config contains `st2_user_data` option and overwritten with user data from that config option.

Imo, that's very unfriendly and unexpected behavior. For one, we should log when we do that and we should allow user to explicitly pass `user_data` parameter to `ec2_run_instances` action which takes precedence over the config value.