### PR TITLE
Update `st2_user_data` to take raw data as input as an alternative to file path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.0
+- Update `st2_user_data` to take raw data as input as an alternative to file path.
+
 ## 1.1.1
 
 - Use non-deprecated runner name and change ``runner_type`` from ``run-remote`` to

--- a/README.md
+++ b/README.md
@@ -55,15 +55,21 @@ break the configuration where iam roles are being used
 
 ## st2_user_data
 
-Optionally, you can set the user_data to set a default file to be used during new instance
-creation.  Put your user_data file somewhere accessible by the StackStorm user, and use
-the st2_user_data config option to set it.
+Optionally, you can add the [`user_data`](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html) with set of provisioning instructions to be used during the new instance
+creation.
 
 ```yaml
 st2_user_data: "/full/path/to/file"
  ```
-
+Put your user_data file somewhere accessible by the StackStorm user, and use the st2_user_data config option to set it.
 This file/script will be used for all invocations of the ec2_run_instances action
+
+Alternatively, user data can be specified inline:
+```yaml
+st2_user_data: |
+  #!/bin/bash
+  echo "I'm EC2 user data: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html"
+```
 
 ## Actions
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ st2_user_data: ""
  ```
 
 In previous versions there was a 'setup' object within the config, which has been deprecated. This will
-break the configuration where iam roles are being used
+break the configuration where iam roles are being used:
 
 * ``service_notifications_sensor.host`` - Listen host for the HTTP interface.
 * ``service_notifications_sensor.port`` - Listen port for the HTTP interface.
@@ -55,14 +55,14 @@ break the configuration where iam roles are being used
 
 ## st2_user_data
 
-Optionally, you can add the [`user_data`](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html) with set of provisioning instructions to be used during the new instance
+Optionally, you can add the [`user_data`](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html) with a set of provisioning instructions to be used during the new instance
 creation.
 
+Put your user_data file somewhere accessible by the StackStorm user, and use the st2_user_data config option to set it.
+This file/script will be used for all invocations of the ec2_run_instances action:
 ```yaml
 st2_user_data: "/full/path/to/file"
  ```
-Put your user_data file somewhere accessible by the StackStorm user, and use the st2_user_data config option to set it.
-This file/script will be used for all invocations of the ec2_run_instances action
 
 Alternatively, user data can be specified inline:
 ```yaml

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -1,3 +1,4 @@
+import os
 import re
 import eventlet
 import importlib
@@ -22,18 +23,20 @@ class BaseAction(Action):
             'aws_access_key_id': None,
             'aws_secret_access_key': None
         }
-        self.user_data_file = config.get('st2_user_data', None)
         self.debug = config.get('debug', False)
 
         self.userdata = None
-
-        # Read in default user data
-        if self.user_data_file:
-            try:
-                with open(self.user_data_file, 'r') as fp:
-                    self.userdata = fp.read()
-            except IOError as e:
-                self.logger.error(e)
+        if config.get('st2_user_data', None):
+            # Check if string "looks" like a normal absolute path
+            if os.path.isabs(config['st2_user_data']) and '\n' not in config['st2_user_data']:
+                # Read in default user data from file
+                try:
+                    with open(config['st2_user_data'], 'r') as fp:
+                        self.userdata = fp.read()
+                except IOError as e:
+                    self.logger.error(e)
+            else:
+                self.userdata = config['st2_user_data']
 
         # Note: In old static config credentials and region are under "setup" key and with a new
         # dynamic config values are top-level

--- a/actions/run.py
+++ b/actions/run.py
@@ -22,7 +22,7 @@ class ActionManager(action.BaseAction):
 
             if user_data:
                 self.logger.info('Passing in default user_data specified as st2_user_data config '
-                                 'option (%s file)' % (self.user_data_file))
+                                 'option (%s ...)' % (self.st2_user_data()[:15]))
                 kwargs['user_data'] = self.st2_user_data()
         if aws_action == 'create_tags':
             # Skip "Tags" parameter and pass "tags" as is unless it is a string.

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -15,7 +15,9 @@
     required: true
     default: 'us-east-1'
   st2_user_data:
-    description: "The file for all invocations of the 'aws.ec2_run_instances' action"
+    description: >
+      Raw content or filepath with EC2 user data: automated configuration tasks or scripts executed after the instance starts.
+      Used as default for all 'ec2_run_instances' invocations if no custom user-data provided via action parameters.
     type: "string"
   debug:
     type: "boolean"

--- a/pack.yaml
+++ b/pack.yaml
@@ -20,6 +20,6 @@ keywords:
   - lambda
   - kinesis
 
-version : 1.1.1
+version : 1.2.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
This PR allows passing EC2 user data inline, like:

```yaml
st2_user_data: |
  #!/bin/bash
  echo "I'm EC2 user data: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html"
```

Needed for K8s work we're doing. In distributed environment it's easier to pass raw data inline for pack config to consume, instead of sharing a file with user data between all nodes.