### PR TITLE
Support Python 3 everywhere

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.3
+- Support Python 3 everywhere
+
 ## 1.2.2
 - Fix `sqs_sensor` to parse payload as dictionary (so that it actually works)
 

--- a/actions/lib/ec2parsers.py
+++ b/actions/lib/ec2parsers.py
@@ -284,7 +284,7 @@ class ResultSets(object):
                 v_list = []
                 for item in v:
                     # avoid touching the basic types.
-                    if isinstance(item, (basestring, bool, int, long, float)):
+                    if isinstance(item, (bool, float) + six.string_types + six.integer_types):
                         v_list.append(v)
                     else:
                         v_list.append(str(item))

--- a/pack.yaml
+++ b/pack.yaml
@@ -24,3 +24,6 @@ python_versions:
   - "2"
 author : StackStorm, Inc.
 email : info@stackstorm.com
+python_versions:
+  - "2"
+  - "3"

--- a/pack.yaml
+++ b/pack.yaml
@@ -19,7 +19,7 @@ keywords:
   - SQS
   - lambda
   - kinesis
-version : 1.2.2
+version : 1.2.3
 python_versions:
   - "2"
 author : StackStorm, Inc.


### PR DESCRIPTION
Updates the last little bit of code tying us to Python 2, adds explicit Python 2 and 3 support, and bumps version to `1.2.3`.

Note that `six.string_types` and `six.integer_types` are both defined as tuples whose elements are the respective types.