### PR TITLE
Multiaccount action (ADDENDUM)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.2
+- Solved the bug regarding `aws_session_token` parameter for `boto3` cross account authentication in `actions.py`.
+
 ## 1.3.1
 - Actions support multiaccount integration.
 

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -129,6 +129,8 @@ class BaseAction(Action):
     def get_boto3_session(self, resource):
         region = self.credentials['region']
         del self.credentials['region']
+        if 'security_token' in self.credentials:
+            self.credentials['aws_session_token'] = self.credentials.pop('security_token')
         return boto3.client(resource, region_name=region, **self.credentials)
 
     def split_tags(self, tags):

--- a/pack.yaml
+++ b/pack.yaml
@@ -19,7 +19,7 @@ keywords:
   - SQS
   - lambda
   - kinesis
-version : 1.3.1
+version : 1.3.2
 author : StackStorm, Inc.
 email : info@stackstorm.com
 python_versions:


### PR DESCRIPTION
Found a bug in the credential dictionary due to difference between `boto3` and the other libraries methods headers.