### PR TITLE
Modified action.py in order to have filters in a more conveinent way

### DIFF
--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -221,6 +221,19 @@ class BaseAction(Action):
             method_fqdn = '%s.%s.%s' % (module_path, cls, action)
             self.logger.debug('Calling method "%s" with kwargs: %s' % (method_fqdn, str(kwargs)))
 
+        if 'Filters' in kwargs.keys():
+            boto3_compliant_filters = []
+            for specified_filter in kwargs['Filters']:
+                keyval = specified_filter.split('=')
+                vals = []
+                for entry in boto3_compliant_filters:
+                    if entry['Name'] == keyval[0]:
+                        vals = entry['Values']
+                        boto3_compliant_filters.remove(entry)
+                vals.append(keyval[1])
+                boto3_compliant_filters.append({'Name': keyval[0], 'Values': vals})
+            kwargs['Filters'] = boto3_compliant_filters
+
         resultset = getattr(obj, action)(**kwargs)
         formatted = self.resultsets.formatter(resultset)
         return formatted if isinstance(formatted, list) else [formatted]
@@ -232,5 +245,17 @@ class BaseAction(Action):
             function_fqdn = '%s.%s' % (module_path, action)
             self.logger.debug('Calling function "%s" with kwargs: %s' % (function_fqdn,
                                                                          str(kwargs)))
+        if 'Filters' in kwargs.keys():
+            boto3_compliant_filters = []
+            for specified_filter in kwargs['Filters']:
+                keyval = specified_filter.split('=')
+                vals = []
+                for entry in boto3_compliant_filters:
+                    if entry['Name'] == keyval[0]:
+                        vals = entry['Values']
+                        boto3_compliant_filters.remove(entry)
+                vals.append(keyval[1])
+                boto3_compliant_filters.append({'Name': keyval[0], 'Values': vals})
+            kwargs['Filters'] = boto3_compliant_filters
 
         return getattr(module, action)(**kwargs)


### PR DESCRIPTION
Fixes #108 

With this fix, it is easier to specify the filters to use with the `st2 run` command.

The `Filters` parameter will now have to be specified like this : 
```
Filters=Key1=Value1,Key2=Value2...
```
If you need to have multiple values for a key, you just have to set the same key multiple times.

For example, if I want to describe all the instances that have the `Name` tag set to `prod-web` or `prod-db`, I will just use the following command : 

```
st2 run aws.ec2_describe_instances Filters=tag:Name=prod-web,tag:Name=prod-db account_id=xxxxxxxxxxxx region=my-aws-region
```

I will stay available if you have questions.

Best regards