### PR TITLE
Delete duplicate headers parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1
+- Deleted duplicate `headers` parameter in `actions/apigateway_test_invoke_authorizer.yaml` and
+  `actions/apigateway_test_invoke_method.yaml`
+
 ## 2.0.0
 
 * Drop Python 2.7 support

--- a/actions/apigateway_test_invoke_authorizer.yaml
+++ b/actions/apigateway_test_invoke_authorizer.yaml
@@ -17,8 +17,6 @@ parameters:
   cls:
     default: apigateway
     type: string
-  headers:
-    type: string
   module_path:
     default: boto3
     immutable: true

--- a/actions/apigateway_test_invoke_method.yaml
+++ b/actions/apigateway_test_invoke_method.yaml
@@ -17,8 +17,6 @@ parameters:
   cls:
     default: apigateway
     type: string
-  headers:
-    type: string
   module_path:
     default: boto3
     immutable: true

--- a/pack.yaml
+++ b/pack.yaml
@@ -19,7 +19,7 @@ keywords:
   - SQS
   - lambda
   - kinesis
-version: 2.0.0
+version: 2.0.1
 author : StackStorm, Inc.
 email : info@stackstorm.com
 python_versions:


### PR DESCRIPTION
Deleted duplicate headers parameter in files:

actions/apigateway_test_invoke_authorizer.yaml
actions/apigateway_test_invoke_method.yaml

to fix issue #114 
